### PR TITLE
add fiat order history endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+### Added
+- New Fiat endpoints
+    - `GET /sapi/v1/fiat/orders` to query user fiat deposit and withdraw history 
+    - `GET /sapi/v1/fiat/payments` to query user fiat payments history 
+
 ## 1.3.0 - 2021-07-22
 ### Added
 - New endpoints for Wallet:

--- a/binance/spot/__init__.py
+++ b/binance/spot/__init__.py
@@ -200,3 +200,7 @@ class Spot(API):
     from binance.spot.bswap import bswap_request_quote
     from binance.spot.bswap import bswap_swap
     from binance.spot.bswap import bswap_swap_history
+
+    # Fiat
+    from binance.spot.fiat import fiat_order_history
+    from binance.spot.fiat import fiat_payment_history

--- a/binance/spot/fiat.py
+++ b/binance/spot/fiat.py
@@ -1,0 +1,40 @@
+def fiat_order_history(self, transactionType: int, **kwargs):
+    """Get Fiat Deposit/Withdraw History (USER_DATA)
+
+    GET /sapi/v1/fiat/orders
+
+    https://binance-docs.github.io/apidocs/spot/en/#get-fiat-deposit-withdraw-history-user_data
+
+    Args:
+      transactionType (int): 0-deposit,1-withdraw
+    Keyword Args:
+      beginTime (int, optional)
+      endTime (int, optional)
+      page (int, optional): default 1
+      rows (int, optional): default 100, max 500
+      recvWindow (int, optional): The value cannot be greater than 60000
+    """
+
+    payload = {"transactionType": transactionType, **kwargs}
+    return self.sign_request("GET", "/sapi/v1/fiat/orders", payload)
+
+
+def fiat_payment_history(self, transactionType: int, **kwargs):
+    """Get Fiat Payments History (USER_DATA)
+
+    GET /sapi/v1/fiat/payments
+
+    https://binance-docs.github.io/apidocs/spot/en/#get-fiat-payments-history-user_data
+
+    Args:
+      transactionType (int): 0-buy,1-sell
+    Keyword Args:
+      beginTime (int, optional)
+      endTime (int, optional)
+      page (int, optional): default 1
+      rows (int, optional): default 100, max 500
+      recvWindow (int, optional): The value cannot be greater than 60000
+    """
+
+    payload = {"transactionType": transactionType, **kwargs}
+    return self.sign_request("GET", "/sapi/v1/fiat/payments", payload)

--- a/docs/source/CHANGELOG.rst
+++ b/docs/source/CHANGELOG.rst
@@ -4,6 +4,11 @@ Changelog
 
 Unreleased
 ----------
+* New Fiat endpoints
+
+  ** `GET /sapi/v1/fiat/orders` to query user fiat deposit and withdraw history 
+  ** `GET /sapi/v1/fiat/payments` to query user fiat payments history 
+
 
 1.3.0 - 2021-07-22
 ------------------

--- a/docs/source/binance.spot.fiat.rst
+++ b/docs/source/binance.spot.fiat.rst
@@ -1,0 +1,10 @@
+Fiat Endpoints
+==============
+
+Get Fiat Order History (USER_DATA)
+---------------------------------------------
+.. autofunction:: binance.spot.fiat.fiat_order_history
+
+Get Fiat Payments History (USER_DATA)
+---------------------------------------------
+.. autofunction:: binance.spot.fiat.fiat_payment_history

--- a/examples/spot/fiat/fiat_order_history.py
+++ b/examples/spot/fiat/fiat_order_history.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python
+
+import logging
+from binance.spot import Spot as Client
+from binance.lib.utils import config_logging
+from binance.error import ClientError
+
+config_logging(logging, logging.DEBUG)
+
+key = ""
+secret = ""
+
+client = Client(key, secret)
+
+try:
+    response = client.fiat_order_history(0)
+    logging.info(response)
+except ClientError as error:
+    logging.error(
+        "Found error. status: {}, error code: {}, error message: {}".format(
+            error.status_code, error.error_code, error.error_message
+        )
+    )

--- a/examples/spot/fiat/fiat_payment_history.py
+++ b/examples/spot/fiat/fiat_payment_history.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python
+
+import logging
+from binance.spot import Spot as Client
+from binance.lib.utils import config_logging
+from binance.error import ClientError
+
+config_logging(logging, logging.DEBUG)
+
+key = ""
+secret = ""
+
+client = Client(key, secret)
+
+try:
+    response = client.fiat_payment_history(0)
+    logging.info(response)
+except ClientError as error:
+    logging.error(
+        "Found error. status: {}, error code: {}, error message: {}".format(
+            error.status_code, error.error_code, error.error_message
+        )
+    )

--- a/tests/spot/fiat/test_fiat_order_history.py
+++ b/tests/spot/fiat/test_fiat_order_history.py
@@ -1,0 +1,34 @@
+import responses
+
+from tests.util import random_str, timestamp
+from tests.util import mock_http_response
+from urllib.parse import urlencode
+from binance.spot import Spot as Client
+from binance.error import ParameterRequiredError, ClientError
+
+mock_item = {"key_1": "value_1", "key_2": "value_2"}
+
+key = random_str()
+secret = random_str()
+
+transactionType = 0
+
+params = {
+    "beginTime": timestamp(),
+    "endTime": timestamp(),
+    "page": 1,
+    "rows": 100,
+}
+
+
+@mock_http_response(
+    responses.GET,
+    "/sapi/v1/fiat/orders\\?transactionType=0&" + urlencode(params),
+    mock_item,
+    200,
+)
+def test_fiat_order_history():
+    """Tests the API endpoint to get fiat order history"""
+
+    client = Client(key, secret)
+    response = client.fiat_order_history(transactionType, **params)

--- a/tests/spot/fiat/test_fiat_payment_history.py
+++ b/tests/spot/fiat/test_fiat_payment_history.py
@@ -1,0 +1,34 @@
+import responses
+
+from tests.util import random_str, timestamp
+from tests.util import mock_http_response
+from urllib.parse import urlencode
+from binance.spot import Spot as Client
+from binance.error import ParameterRequiredError, ClientError
+
+mock_item = {"key_1": "value_1", "key_2": "value_2"}
+
+key = random_str()
+secret = random_str()
+
+transactionType = 0
+
+params = {
+    "beginTime": timestamp(),
+    "endTime": timestamp(),
+    "page": 1,
+    "rows": 100,
+}
+
+
+@mock_http_response(
+    responses.GET,
+    "/sapi/v1/fiat/payments\\?transactionType=0&" + urlencode(params),
+    mock_item,
+    200,
+)
+def test_fiat_payment_history():
+    """Tests the API endpoint to get fiat payments history"""
+
+    client = Client(key, secret)
+    response = client.fiat_payment_history(transactionType, **params)


### PR DESCRIPTION
    - `GET /sapi/v1/fiat/orders` to query user fiat deposit and withdraw history 
    - `GET /sapi/v1/fiat/payments` to query user fiat payments history