### PR TITLE
Binance Convert API Endpoint added

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Added
+- New endpoint for Convert:
+   - GET /sapi/v1/convert/tradeFlow to support user query convert trade history records
+
 ## 1.8.0 - 2021-11-25
 
 ### Added
@@ -46,7 +52,7 @@
     - `GET /sapi/v1/bswap/poolConfigure` to get pool configure
     - `GET /sapi/v1/bswap/addLiquidityPreview` to calculate expected share amount for adding liquidity in single or dual token
     - `GET /sapi/v1/bswap/removeLiquidityPreview` to calculate expected asset amount of single token redemption or dual token redemption
-    
+
 ## 1.5.0 - 2021-08-17
 
 ### Changed
@@ -60,8 +66,8 @@
 
 ### Added
 - New Fiat endpoints:
-    - `GET /sapi/v1/fiat/orders` to query user fiat deposit and withdraw history 
-    - `GET /sapi/v1/fiat/payments` to query user fiat payments history 
+    - `GET /sapi/v1/fiat/orders` to query user fiat deposit and withdraw history
+    - `GET /sapi/v1/fiat/payments` to query user fiat payments history
 
 ### Fixed
  - Typo in `margin_max_transferable`
@@ -71,7 +77,7 @@
 - New endpoints for Wallet:
     - `POST /sapi/v1/asset/get-funding-asset` to query funding wallet, includes Binance Pay, Binance Card, Binance Gift Card, Stock Token
     - `GET /sapi/v1/account/apiRestrictions` to query user API Key permission
-    
+
 ## 1.2.0 - 2021-07-12
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added
 - New endpoint for Convert:
-   - GET /sapi/v1/convert/tradeFlow to support user query convert trade history records
+    - `GET /sapi/v1/convert/tradeFlow` to support user query convert trade history records
 
 ## 1.8.0 - 2021-11-25
 

--- a/binance/spot/__init__.py
+++ b/binance/spot/__init__.py
@@ -229,3 +229,6 @@ class Spot(API):
 
     # PAY
     from binance.spot.pay import pay_history
+
+    # CONVERT
+    from binance.spot.convert import my_converts

--- a/binance/spot/convert.py
+++ b/binance/spot/convert.py
@@ -1,7 +1,22 @@
 from binance.lib.utils import check_required_parameters
 
 
-def my_converts(self, startTime, endTime, **kwargs):
+def convert_trade_history(self, startTime, endTime, **kwargs):
+    """Convert Trade History (USER_DATA)
+
+    Get convert history for a specific account.
+
+    GET /sapi/v1/convert/tradeFlow
+
+    https://binance-docs.github.io/apidocs/spot/en/#convert-endpoints
+
+    Args:
+        startTime (int)
+        endTime (int)
+    Keyword Args:
+        limit (int, optional): Default Value: 500; Max Value: 1000
+        recvWindow (int, optional)
+    """
     check_required_parameters(
         [
             [startTime, "startTime"],

--- a/binance/spot/convert.py
+++ b/binance/spot/convert.py
@@ -1,7 +1,7 @@
 from binance.lib.utils import check_required_parameters
 
 
-def convert_trade_history(self, startTime, endTime, **kwargs):
+def convert_trade_history(self, startTime: int, endTime: int, **kwargs):
     """Convert Trade History (USER_DATA)
 
     Get convert history for a specific account.

--- a/binance/spot/convert.py
+++ b/binance/spot/convert.py
@@ -14,15 +14,10 @@ def convert_trade_history(self, startTime, endTime, **kwargs):
         startTime (int)
         endTime (int)
     Keyword Args:
-        limit (int, optional): Default Value: 500; Max Value: 1000
+        limit (int, optional): Default Value: 100; Max Value: 1000
         recvWindow (int, optional)
     """
-    check_required_parameters(
-        [
-            [startTime, "startTime"],
-            [endTime, "endTime"]
-        ]
-    )
+    check_required_parameters([[startTime, "startTime"], [endTime, "endTime"]])
 
     url_path = "/sapi/v1/convert/tradeFlow"
     payload = {"startTime": startTime, "endTime": endTime, **kwargs}

--- a/binance/spot/convert.py
+++ b/binance/spot/convert.py
@@ -1,0 +1,14 @@
+from binance.lib.utils import check_required_parameters
+
+
+def my_converts(self, startTime, endTime, **kwargs):
+    check_required_parameters(
+        [
+            [startTime, "startTime"],
+            [endTime, "endTime"]
+        ]
+    )
+
+    url_path = "/sapi/v1/convert/tradeFlow"
+    payload = {"startTime": startTime, "endTime": endTime, **kwargs}
+    return self.sign_request("GET", url_path, payload)

--- a/docs/source/CHANGELOG.rst
+++ b/docs/source/CHANGELOG.rst
@@ -2,6 +2,13 @@
 Changelog
 =========
 
+Unreleased
+----------
+
+Added
+^^^^^
+* New endpoint for Convert:
+   * ``GET /sapi/v1/convert/tradeFlow`` to support user query convert trade history records
 
 1.8.0 - 2021-11-25
 ------------------
@@ -91,8 +98,8 @@ Added
 
 * New Fiat endpoints:
 
-  * ``GET /sapi/v1/fiat/orders`` to query user fiat deposit and withdraw history 
-  * ``GET /sapi/v1/fiat/payments`` to query user fiat payments history 
+  * ``GET /sapi/v1/fiat/orders`` to query user fiat deposit and withdraw history
+  * ``GET /sapi/v1/fiat/payments`` to query user fiat payments history
 
 Fixed
 ^^^^^

--- a/docs/source/binance.spot.convert.rst
+++ b/docs/source/binance.spot.convert.rst
@@ -1,0 +1,7 @@
+Convert Enpoints
+================
+
+
+Get Convert Trade History (USER_DATA)
+-------------------------------------
+.. autofunction:: binance.spot.convert.convert_trade_history

--- a/examples/spot/convert/convert.py
+++ b/examples/spot/convert/convert.py
@@ -1,0 +1,22 @@
+#! /usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+import logging
+from binance.spot import Spot
+from binance.lib.utils import config_logging
+from datetime import datetime
+
+config_logging(logging, logging.DEBUG)
+
+key = ""
+secret = ""
+
+spot_client = Spot(key, secret)
+
+# datetime uses POSIX timestamp
+start = int(datetime(2021, 11, 15, 23, 59, 59).timestamp() * 1000)
+end = int(datetime(2021, 12, 7, 23, 59, 59).timestamp() * 1000)
+
+converts = spot_client.my_converts(startTime=start, endTime=end)
+
+print(converts)

--- a/examples/spot/convert/convert.py
+++ b/examples/spot/convert/convert.py
@@ -11,7 +11,7 @@ config_logging(logging, logging.DEBUG)
 key = ""
 secret = ""
 
-spot_client = Spot(key, secret)
+spot_client = Spot(key, secret, base_url="https://testnet.binance.vision")
 
 # datetime uses POSIX timestamp
 start = int(datetime(2021, 11, 15, 23, 59, 59).timestamp() * 1000)
@@ -19,4 +19,4 @@ end = int(datetime(2021, 12, 7, 23, 59, 59).timestamp() * 1000)
 
 converts = spot_client.my_converts(startTime=start, endTime=end)
 
-print(converts)
+logging.info(converts)

--- a/tests/spot/convert/test_convert_trade_history.py
+++ b/tests/spot/convert/test_convert_trade_history.py
@@ -21,7 +21,7 @@ def test_convert_trade_history_without_startTime():
     """Tests the API endpoint to retrieve convert trade history without startTime"""
 
     client = Client(key, secret)
-    client.convert_trade_history.when.called_with(endTime=1597130241000).should.throw(
+    client.convert_trade_history.when.called_with(startTime="", endTime=1597130241000).should.throw(
         ParameterRequiredError
     )
 
@@ -30,7 +30,7 @@ def test_convert_trade_history_without_endTime():
     """Tests the API endpoint to retrieve convert trade history without endTime"""
 
     client = Client(key, secret)
-    client.convert_trade_history.when.called_with(startTime=1597130241000).should.throw(
+    client.convert_trade_history.when.called_with(startTime=1597130241000, endTime="").should.throw(
         ParameterRequiredError
     )
 

--- a/tests/spot/convert/test_convert_trade_history.py
+++ b/tests/spot/convert/test_convert_trade_history.py
@@ -38,7 +38,7 @@ def test_convert_trade_history_without_endTime():
 @mock_http_response(
     responses.GET, "/sapi/v1/convert/tradeFlow\\?" + urlencode(params), mock_item, 200
 )
-def test_futures_transfer_history():
+def test_convert_trade_history():
     """Tests the API endpoint to retrieve convert trade history"""
 
     client = Client(key, secret)

--- a/tests/spot/convert/test_convert_trade_history.py
+++ b/tests/spot/convert/test_convert_trade_history.py
@@ -18,21 +18,19 @@ params = {
 
 
 def test_convert_trade_history_without_startTime():
-    """Tests the API endpoint to retreive convert trade history without startTime"""
+    """Tests the API endpoint to retrieve convert trade history without startTime"""
 
-    params = {"startTime": "", "endTime": "1597130241000"}
     client = Client(key, secret)
-    client.convert_trade_history.when.called_with(**params).should.throw(
+    client.convert_trade_history.when.called_with(endTime=1597130241000).should.throw(
         ParameterRequiredError
     )
 
 
 def test_convert_trade_history_without_endTime():
-    """Tests the API endpoint to retreive convert trade history without endTime"""
+    """Tests the API endpoint to retrieve convert trade history without endTime"""
 
-    params = {"startTime": "1597130241000", "endTime": ""}
     client = Client(key, secret)
-    client.convert_trade_history.when.called_with(**params).should.throw(
+    client.convert_trade_history.when.called_with(startTime=1597130241000).should.throw(
         ParameterRequiredError
     )
 
@@ -41,7 +39,7 @@ def test_convert_trade_history_without_endTime():
     responses.GET, "/sapi/v1/convert/tradeFlow\\?" + urlencode(params), mock_item, 200
 )
 def test_futures_transfer_history():
-    """Tests the API endpoint to retreive convert trade history"""
+    """Tests the API endpoint to retrieve convert trade history"""
 
     client = Client(key, secret)
     response = client.futures_transfer_history(**params)

--- a/tests/spot/convert/test_convert_trade_history.py
+++ b/tests/spot/convert/test_convert_trade_history.py
@@ -1,0 +1,48 @@
+import responses
+from urllib.parse import urlencode
+from tests.util import random_str
+from tests.util import mock_http_response
+from tests.util import current_timestamp
+from binance.spot import Spot as Client
+from binance.error import ParameterRequiredError
+
+mock_item = {"key_1": "value_1", "key_2": "value_2"}
+key = random_str()
+secret = random_str()
+
+
+params = {
+    "startTime": current_timestamp(),
+    "endTime": current_timestamp(),
+}
+
+
+def test_convert_trade_history_without_startTime():
+    """Tests the API endpoint to retreive convert trade history without startTime"""
+
+    params = {"startTime": "", "endTime": "1597130241000"}
+    client = Client(key, secret)
+    client.convert_trade_history.when.called_with(**params).should.throw(
+        ParameterRequiredError
+    )
+
+
+def test_convert_trade_history_without_endTime():
+    """Tests the API endpoint to retreive convert trade history without endTime"""
+
+    params = {"startTime": "1597130241000", "endTime": ""}
+    client = Client(key, secret)
+    client.convert_trade_history.when.called_with(**params).should.throw(
+        ParameterRequiredError
+    )
+
+
+@mock_http_response(
+    responses.GET, "/sapi/v1/convert/tradeFlow\\?" + urlencode(params), mock_item, 200
+)
+def test_futures_transfer_history():
+    """Tests the API endpoint to retreive convert trade history"""
+
+    client = Client(key, secret)
+    response = client.futures_transfer_history(**params)
+    response.should.equal(mock_item)


### PR DESCRIPTION
Moin,

I have added the Binance API Convert Endpoint to the binance-connector-python

**Changes:**
- Added file `binance/spot/convert.py`  --  Contains method my_converts with the `/sapi/v1/convert/tradeFlow` endpoint.
- Modified `binance/spot/__init__.py` -- Added include statement for convert endpoint.
- Added file `examples/spot/convert` -- Demonstrates the usage of the convert api endpoint.

I hope this helps, cheers.
