### PR TITLE
add symbols query param to tricker_price_method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -144,3 +144,9 @@
 
 ### Added
 - First release, please find details from `README.md`
+
+
+# Unreleased
+
+### Added
+- add symbols query parameter support to ticker_price method

--- a/binance/spot/market.py
+++ b/binance/spot/market.py
@@ -188,7 +188,7 @@ def ticker_24hr(self, symbol: str = None):
     return self.query("/api/v3/ticker/24hr", params)
 
 
-def ticker_price(self, symbol: str = None):
+def ticker_price(self, symbol: str = None, symbols: list = None):
     """Symbol Price Ticker
 
     GET /api/v3/ticker/price
@@ -197,10 +197,16 @@ def ticker_price(self, symbol: str = None):
 
     Args:
         symbol (str, optional): the trading pair
+        symbols (list, optional): list of trading pairs
+
     """
 
+    if symbol and symbols:
+        raise ParameterArgumentError("symbol and symbols cannot be sent together.")
+    check_type_parameter(symbols, "symbols", list)
     params = {
         "symbol": symbol,
+        "symbols": convert_list_to_json_array(symbols)
     }
     return self.query("/api/v3/ticker/price", params)
 

--- a/examples/spot/market/ticker_price.py
+++ b/examples/spot/market/ticker_price.py
@@ -7,5 +7,8 @@ from binance.lib.utils import config_logging
 config_logging(logging, logging.DEBUG)
 
 spot_client = Client(base_url="https://testnet.binance.vision")
-
-logging.info(spot_client.ticker_price("BTCUSDT"))
+symbols = ["BTCUSDT", "BNBUSDT"]
+symbol = "BNBUSDT"
+logging.info(spot_client.ticker_price())
+logging.info(spot_client.ticker_price(symbol=symbol))
+logging.info(spot_client.ticker_price(symbols=symbols))

--- a/tests/spot/market/test_ticker_price.py
+++ b/tests/spot/market/test_ticker_price.py
@@ -2,8 +2,10 @@ from binance.spot import Spot as Client
 import responses
 
 from tests.util import mock_http_response
+from urllib.parse import urlencode
 
 mock_item = {"key_1": "value_1", "key_2": "value_2"}
+params = {"symbols": '["BTCUSDT", "ETHUSDT", "BNBUSDT"]'}
 
 
 @mock_http_response(responses.GET, "/api/v3/ticker/price", mock_item, 200)
@@ -18,9 +20,22 @@ def test_ticker_price_without_pair():
 @mock_http_response(
     responses.GET, "/api/v3/ticker/price\\?symbol=BTCUSDT", mock_item, 200
 )
-def test_ticker_price():
-    """Tests the API endpoint to get price ticker from one pair"""
+def test_ticker_price_one_symbol():
+    """Tests the API endpoint to get price ticker from one pair with one symbol"""
 
     api = Client()
-    response = api.ticker_price("BTCUSDT")
+    symbol = "BTCUSDT"
+    response = api.ticker_price(symbol=symbol)
+    response.should.equal(mock_item)
+
+
+@mock_http_response(
+    responses.GET, "/api/v3/ticker/price\\?" + urlencode(params), mock_item, 200
+)
+def test_ticker_price_multiple_symbols():
+    """Tests the API endpoint to get price ticker from one pair with one symbol"""
+
+    api = Client()
+    symbols = ["BTCUSDT", "ETHUSDT", "BNBUSDT"]
+    response = api.ticker_price(symbols=symbols)
     response.should.equal(mock_item)


### PR DESCRIPTION
According to binance api change log : 2022-05-17
ticker api ("GET /api/v3/ticker/price") will support multi symbol 
so I added this 