### PR TITLE
BUG(FIXED)  ("SSL error: unregistered scheme (in )"), code: 1006

### DIFF
--- a/binance/websocket/websocket_client.py
+++ b/binance/websocket/websocket_client.py
@@ -1,6 +1,11 @@
+import os
 import json
+import certifi
 from twisted.internet import reactor
 from binance.websocket.binance_socket_manager import BinanceSocketManager
+
+# To reference the installed certificate authority (CA) bundle, you can use the built-in function:
+os.environ['SSL_CERT_FILE'] = certifi.where()
 
 
 class BinanceWebsocketClient(BinanceSocketManager):


### PR DESCRIPTION
Fixed a connection error, by adding: To reference the installed certificate authority (CA) bundle, you can use the built-in function:

"""
WebSocket connection closed: connection was closed uncleanly ("SSL error: unregistered scheme (in )"), code: 1006, clean: False, reason: connection was closed uncleanly ("SSL error: unregistered scheme (in )") Lost connection to Server. Reason: [Failure instance: Traceback (failure with no frames): <class 'twisted.internet.error.ConnectionDone'>: Connection was closed cleanly. ]
"""

- Using the module certifi
- Append certifi.where() to os.environ["SSL_CERT"_FILE"]