### PR TITLE
Add method 'start' for explicit control in websocket clients

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## Unreleased
+### Changed
+- Include a "start" method in WebSocket clients to initiate the thread once it has been initialized.
 ## 3.4.0 - 2023-10-07
 ### Added
 - Portfolio endpoints:

--- a/README.md
+++ b/README.md
@@ -246,6 +246,8 @@ def message_handler(_, message):
 
 my_client = SpotWebsocketAPIClient(on_message=message_handler)
 
+my_client.start()
+
 my_client.ticker(symbol="BNBBUSD", type="FULL")
 
 time.sleep(5)
@@ -262,6 +264,8 @@ def message_handler(_, message):
     logging.info(message)
 
 my_client = SpotWebsocketStreamClient(on_message=message_handler)
+
+my_client.start()
 
 # Subscribe to a single symbol stream
 my_client.agg_trade(symbol="bnbusdt")
@@ -305,6 +309,8 @@ proxies = { 'http': 'http://1.2.3.4:8080' }
 
 my_client = SpotWebsocketAPIClient(on_message=message_handler, proxies=proxies)
 
+my_client.start()
+
 my_client.ticker(symbol="BNBBUSD", type="FULL")
 
 time.sleep(5)
@@ -323,6 +329,8 @@ def message_handler(_, message):
 proxies = { 'http': 'http://1.2.3.4:8080' }
 
 my_client = SpotWebsocketStreamClient(on_message=message_handler, proxies=proxies)
+
+my_client.start()
 
 # Subscribe to a single symbol stream
 my_client.agg_trade(symbol="bnbusdt")
@@ -354,7 +362,7 @@ Example file "examples/websocket_api/app_demo.py" demonstrates how Websocket API
 ### Connector v1 and v2
 
 ```python
-from binance.websocket.spot.websocket_client import SpotWebsocketClient as WebsocketClient
+from binance.websocket.spot.websocket_stream import SpotWebsocketStreamClient as WebsocketClient
 
 def message_handler(message):
     print(message)

--- a/binance/websocket/websocket_client.py
+++ b/binance/websocket/websocket_client.py
@@ -37,6 +37,7 @@ class BinanceWebsocketClient:
             proxies,
         )
 
+    def start(self):
         # start the thread
         self.socket_manager.start()
         self.logger.debug("Binance WebSocket Client started.")
@@ -106,7 +107,8 @@ class BinanceWebsocketClient:
 
     def stop(self, id=None):
         self.socket_manager.close()
-        self.socket_manager.join()
+        if self.socket_manager.is_alive():
+            self.socket_manager.join()
 
     def list_subscribe(self, id=None):
         """sending the list subscription message, e.g.

--- a/examples/websocket/spot/websocket_api/account/account.py
+++ b/examples/websocket/spot/websocket_api/account/account.py
@@ -27,6 +27,8 @@ my_client = SpotWebsocketAPIClient(
     on_close=on_close,
 )
 
+my_client.start()
+
 
 my_client.account()
 

--- a/examples/websocket/spot/websocket_api/account/my_trades.py
+++ b/examples/websocket/spot/websocket_api/account/my_trades.py
@@ -27,6 +27,8 @@ my_client = SpotWebsocketAPIClient(
     on_close=on_close,
 )
 
+my_client.start()
+
 
 my_client.order_history(symbol="BNBUSDT", limit=10)
 

--- a/examples/websocket/spot/websocket_api/account/oco_history.py
+++ b/examples/websocket/spot/websocket_api/account/oco_history.py
@@ -27,6 +27,8 @@ my_client = SpotWebsocketAPIClient(
     on_close=on_close,
 )
 
+my_client.start()
+
 
 my_client.oco_history(fromId=1, limit=10)
 

--- a/examples/websocket/spot/websocket_api/account/order_history.py
+++ b/examples/websocket/spot/websocket_api/account/order_history.py
@@ -27,6 +27,8 @@ my_client = SpotWebsocketAPIClient(
     on_close=on_close,
 )
 
+my_client.start()
+
 
 my_client.order_history(id="123", symbol="BNBUSDT", limit=10)
 

--- a/examples/websocket/spot/websocket_api/account/order_rate_limit.py
+++ b/examples/websocket/spot/websocket_api/account/order_rate_limit.py
@@ -27,6 +27,8 @@ my_client = SpotWebsocketAPIClient(
     on_close=on_close,
 )
 
+my_client.start()
+
 
 my_client.order_rate_limit()
 

--- a/examples/websocket/spot/websocket_api/account/prevented_matches.py
+++ b/examples/websocket/spot/websocket_api/account/prevented_matches.py
@@ -27,6 +27,8 @@ my_client = SpotWebsocketAPIClient(
     on_close=on_close,
 )
 
+my_client.start()
+
 
 my_client.prevented_matches(symbol="BNBUSDT", preventedMatchId=1)
 

--- a/examples/websocket/spot/websocket_api/app_demo.py
+++ b/examples/websocket/spot/websocket_api/app_demo.py
@@ -44,11 +44,15 @@ ws_api_client = SpotWebsocketAPIClient(
     on_close=on_close,
 )
 
+ws_api_client.start()
+
 # make a connection to the websocket stream
 ws_stream_client = SpotWebsocketStreamClient(
     stream_url="wss://testnet.binance.vision",
     on_message=websocket_stream_message_handler,
 )
+
+ws_stream_client.start()
 
 # spot api client to call all restful api endpoints
 spot_api_client = SpotAPIClient(api_key, base_url="https://testnet.binance.vision")

--- a/examples/websocket/spot/websocket_api/market/aggregate_trades.py
+++ b/examples/websocket/spot/websocket_api/market/aggregate_trades.py
@@ -18,6 +18,8 @@ def message_handler(_, message):
 
 my_client = SpotWebsocketAPIClient(on_message=message_handler, on_close=on_close)
 
+my_client.start()
+
 
 my_client.aggregate_trades(symbol="BNBBUSD", limit=1, fromId=0)
 

--- a/examples/websocket/spot/websocket_api/market/all.py
+++ b/examples/websocket/spot/websocket_api/market/all.py
@@ -18,6 +18,8 @@ def message_handler(_, message):
 
 my_client = SpotWebsocketAPIClient(on_message=message_handler, on_close=on_close)
 
+my_client.start()
+
 
 my_client.ping_connectivity()
 time.sleep(2)

--- a/examples/websocket/spot/websocket_api/market/avg_price.py
+++ b/examples/websocket/spot/websocket_api/market/avg_price.py
@@ -18,6 +18,8 @@ def message_handler(_, message):
 
 my_client = SpotWebsocketAPIClient(on_message=message_handler, on_close=on_close)
 
+my_client.start()
+
 
 my_client.avg_price(symbol="BNBBUSD")
 

--- a/examples/websocket/spot/websocket_api/market/exchange_info.py
+++ b/examples/websocket/spot/websocket_api/market/exchange_info.py
@@ -18,6 +18,8 @@ def message_handler(_, message):
 
 my_client = SpotWebsocketAPIClient(on_message=message_handler, on_close=on_close)
 
+my_client.start()
+
 
 my_client.exchange_info(symbol="BNBBUSD")
 

--- a/examples/websocket/spot/websocket_api/market/historical_trades.py
+++ b/examples/websocket/spot/websocket_api/market/historical_trades.py
@@ -18,6 +18,8 @@ def message_handler(_, message):
 
 my_client = SpotWebsocketAPIClient(on_message=message_handler, on_close=on_close)
 
+my_client.start()
+
 
 my_client.historical_trades(symbol="BNBBUSD", apiKey="", limit=1)
 

--- a/examples/websocket/spot/websocket_api/market/klines.py
+++ b/examples/websocket/spot/websocket_api/market/klines.py
@@ -18,6 +18,8 @@ def message_handler(_, message):
 
 my_client = SpotWebsocketAPIClient(on_message=message_handler, on_close=on_close)
 
+my_client.start()
+
 
 my_client.klines(symbol="BNBBUSD", interval="1m", limit=2)
 

--- a/examples/websocket/spot/websocket_api/market/order_book.py
+++ b/examples/websocket/spot/websocket_api/market/order_book.py
@@ -18,6 +18,8 @@ def message_handler(_, message):
 
 my_client = SpotWebsocketAPIClient(on_message=message_handler, on_close=on_close)
 
+my_client.start()
+
 
 my_client.order_book(symbol="BNBBUSD")
 

--- a/examples/websocket/spot/websocket_api/market/ping_connectivity.py
+++ b/examples/websocket/spot/websocket_api/market/ping_connectivity.py
@@ -18,6 +18,8 @@ def message_handler(_, message):
 
 my_client = SpotWebsocketAPIClient(on_message=message_handler, on_close=on_close)
 
+my_client.start()
+
 # send a message to the server to ping connectivity
 my_client.ping_connectivity(id="my_request_id")
 

--- a/examples/websocket/spot/websocket_api/market/recent_trades.py
+++ b/examples/websocket/spot/websocket_api/market/recent_trades.py
@@ -18,6 +18,8 @@ def message_handler(_, message):
 
 my_client = SpotWebsocketAPIClient(on_message=message_handler, on_close=on_close)
 
+my_client.start()
+
 
 my_client.recent_trades(symbol="BNBBUSD")
 

--- a/examples/websocket/spot/websocket_api/market/server_time.py
+++ b/examples/websocket/spot/websocket_api/market/server_time.py
@@ -18,6 +18,8 @@ def message_handler(_, message):
 
 my_client = SpotWebsocketAPIClient(on_message=message_handler, on_close=on_close)
 
+my_client.start()
+
 
 my_client.server_time()
 

--- a/examples/websocket/spot/websocket_api/market/ticker.py
+++ b/examples/websocket/spot/websocket_api/market/ticker.py
@@ -18,6 +18,8 @@ def message_handler(_, message):
 
 my_client = SpotWebsocketAPIClient(on_message=message_handler, on_close=on_close)
 
+my_client.start()
+
 
 my_client.ticker(symbol="BNBBUSD", type="FULL")
 

--- a/examples/websocket/spot/websocket_api/market/ticker_24hr.py
+++ b/examples/websocket/spot/websocket_api/market/ticker_24hr.py
@@ -18,6 +18,8 @@ def message_handler(_, message):
 
 my_client = SpotWebsocketAPIClient(on_message=message_handler, on_close=on_close)
 
+my_client.start()
+
 
 my_client.ticker_24hr(symbol="BNBBUSD", type="FULL")
 

--- a/examples/websocket/spot/websocket_api/market/ticker_book.py
+++ b/examples/websocket/spot/websocket_api/market/ticker_book.py
@@ -18,6 +18,8 @@ def message_handler(_, message):
 
 my_client = SpotWebsocketAPIClient(on_message=message_handler, on_close=on_close)
 
+my_client.start()
+
 
 my_client.ticker_book(symbol="BNBBUSD")
 

--- a/examples/websocket/spot/websocket_api/market/ticker_price.py
+++ b/examples/websocket/spot/websocket_api/market/ticker_price.py
@@ -18,6 +18,8 @@ def message_handler(_, message):
 
 my_client = SpotWebsocketAPIClient(on_message=message_handler, on_close=on_close)
 
+my_client.start()
+
 
 my_client.ticker_price(symbol="BNBBUSD")
 

--- a/examples/websocket/spot/websocket_api/market/ui_klines.py
+++ b/examples/websocket/spot/websocket_api/market/ui_klines.py
@@ -18,6 +18,8 @@ def message_handler(_, message):
 
 my_client = SpotWebsocketAPIClient(on_message=message_handler, on_close=on_close)
 
+my_client.start()
+
 
 my_client.ui_klines(symbol="BNBBUSD", interval="1m", limit=2)
 

--- a/examples/websocket/spot/websocket_api/trade/cancel_oco_order.py
+++ b/examples/websocket/spot/websocket_api/trade/cancel_oco_order.py
@@ -30,6 +30,8 @@ my_client = SpotWebsocketAPIClient(
 
 my_client.cancel_oco_order(symbol="BNBUSDT", orderListId=15558)
 
+my_client.start()
+
 time.sleep(2)
 
 logging.info("closing ws connection")

--- a/examples/websocket/spot/websocket_api/trade/cancel_open_orders.py
+++ b/examples/websocket/spot/websocket_api/trade/cancel_open_orders.py
@@ -30,6 +30,8 @@ my_client = SpotWebsocketAPIClient(
 
 my_client.cancel_open_orders(symbol="BNBUSDT")
 
+my_client.start()
+
 time.sleep(2)
 
 logging.info("closing ws connection")

--- a/examples/websocket/spot/websocket_api/trade/cancel_order.py
+++ b/examples/websocket/spot/websocket_api/trade/cancel_order.py
@@ -30,6 +30,8 @@ my_client = SpotWebsocketAPIClient(
 
 my_client.cancel_order(symbol="BNBUSDT", orderId=1)
 
+my_client.start()
+
 time.sleep(2)
 
 logging.info("closing ws connection")

--- a/examples/websocket/spot/websocket_api/trade/cancel_replace_order.py
+++ b/examples/websocket/spot/websocket_api/trade/cancel_replace_order.py
@@ -27,6 +27,8 @@ my_client = SpotWebsocketAPIClient(
     on_close=on_close,
 )
 
+my_client.start()
+
 
 my_client.cancel_replace_order(
     symbol="BNBUSDT",

--- a/examples/websocket/spot/websocket_api/trade/get_oco_order.py
+++ b/examples/websocket/spot/websocket_api/trade/get_oco_order.py
@@ -27,6 +27,8 @@ my_client = SpotWebsocketAPIClient(
     on_close=on_close,
 )
 
+my_client.start()
+
 
 my_client.get_oco_order(orderListId=15558)
 

--- a/examples/websocket/spot/websocket_api/trade/get_open_oco_orders.py
+++ b/examples/websocket/spot/websocket_api/trade/get_open_oco_orders.py
@@ -27,6 +27,8 @@ my_client = SpotWebsocketAPIClient(
     on_close=on_close,
 )
 
+my_client.start()
+
 
 my_client.get_open_oco_orders()
 

--- a/examples/websocket/spot/websocket_api/trade/get_open_orders.py
+++ b/examples/websocket/spot/websocket_api/trade/get_open_orders.py
@@ -27,6 +27,7 @@ my_client = SpotWebsocketAPIClient(
     on_close=on_close,
 )
 
+my_client.start()
 
 my_client.get_open_orders(symbol="BNBUSDT")
 

--- a/examples/websocket/spot/websocket_api/trade/get_order.py
+++ b/examples/websocket/spot/websocket_api/trade/get_order.py
@@ -27,6 +27,8 @@ my_client = SpotWebsocketAPIClient(
     on_close=on_close,
 )
 
+my_client.start()
+
 
 my_client.get_order(symbol="BNBUSDT", orderId=1)
 

--- a/examples/websocket/spot/websocket_api/trade/new_oco_order.py
+++ b/examples/websocket/spot/websocket_api/trade/new_oco_order.py
@@ -27,6 +27,8 @@ my_client = SpotWebsocketAPIClient(
     on_close=on_close,
 )
 
+my_client.start()
+
 
 my_client.new_oco_order(
     symbol="BNBUSDT",

--- a/examples/websocket/spot/websocket_api/trade/new_order.py
+++ b/examples/websocket/spot/websocket_api/trade/new_order.py
@@ -27,6 +27,8 @@ my_client = SpotWebsocketAPIClient(
     on_close=on_close,
 )
 
+my_client.start()
+
 
 my_client.new_order(
     id=12345678,

--- a/examples/websocket/spot/websocket_api/trade/new_order_test.py
+++ b/examples/websocket/spot/websocket_api/trade/new_order_test.py
@@ -27,6 +27,7 @@ my_client = SpotWebsocketAPIClient(
     on_close=on_close,
 )
 
+my_client.start()
 
 my_client.new_order_test(
     symbol="BNBUSDT",

--- a/examples/websocket/spot/websocket_api/user_data/user_data_ping.py
+++ b/examples/websocket/spot/websocket_api/user_data/user_data_ping.py
@@ -27,6 +27,8 @@ my_client = SpotWebsocketAPIClient(
     on_close=on_close,
 )
 
+my_client.start()
+
 
 my_client.user_data_ping(listen_key="your_listen_key")
 

--- a/examples/websocket/spot/websocket_api/user_data/user_data_start.py
+++ b/examples/websocket/spot/websocket_api/user_data/user_data_start.py
@@ -27,6 +27,8 @@ my_client = SpotWebsocketAPIClient(
     on_close=on_close,
 )
 
+my_client.start()
+
 
 my_client.user_data_start()
 

--- a/examples/websocket/spot/websocket_api/user_data/user_data_stop.py
+++ b/examples/websocket/spot/websocket_api/user_data/user_data_stop.py
@@ -27,6 +27,8 @@ my_client = SpotWebsocketAPIClient(
     on_close=on_close,
 )
 
+my_client.start()
+
 
 my_client.user_data_stop(listenKey="your_listen_key")
 

--- a/examples/websocket/spot/websocket_stream/agg_trade.py
+++ b/examples/websocket/spot/websocket_stream/agg_trade.py
@@ -14,6 +14,8 @@ def message_handler(_, message):
 
 my_client = SpotWebsocketStreamClient(on_message=message_handler, is_combined=True)
 
+my_client.start()
+
 # Subscribe to a single symbol stream
 my_client.agg_trade(symbol="bnbusdt")
 

--- a/examples/websocket/spot/websocket_stream/all_symbols_mini_ticker.py
+++ b/examples/websocket/spot/websocket_stream/all_symbols_mini_ticker.py
@@ -14,6 +14,7 @@ def message_handler(_, message):
 
 my_client = SpotWebsocketStreamClient(on_message=message_handler)
 
+my_client.start()
 
 # subscribe to all symbols mini ticker stream
 my_client.mini_ticker(symbol="bnbusdt")

--- a/examples/websocket/spot/websocket_stream/all_symbols_ticker.py
+++ b/examples/websocket/spot/websocket_stream/all_symbols_ticker.py
@@ -14,6 +14,7 @@ def message_handler(_, message):
 
 my_client = SpotWebsocketStreamClient(on_message=message_handler)
 
+my_client.start()
 
 # subscribe to all symbols ticker stream
 my_client.ticker()

--- a/examples/websocket/spot/websocket_stream/book_ticker.py
+++ b/examples/websocket/spot/websocket_stream/book_ticker.py
@@ -14,6 +14,7 @@ def message_handler(_, message):
 
 my_client = SpotWebsocketStreamClient(on_message=message_handler)
 
+my_client.start()
 
 my_client.book_ticker(symbol="btcusdt")
 

--- a/examples/websocket/spot/websocket_stream/combined_streams.py
+++ b/examples/websocket/spot/websocket_stream/combined_streams.py
@@ -13,6 +13,7 @@ def message_handler(_, message):
 
 my_client = SpotWebsocketStreamClient(on_message=message_handler, is_combined=True)
 
+my_client.start()
 
 my_client.subscribe(
     stream=["bnbusdt@bookTicker", "ethusdt@kline_1m"],

--- a/examples/websocket/spot/websocket_stream/diff_book_depth.py
+++ b/examples/websocket/spot/websocket_stream/diff_book_depth.py
@@ -14,6 +14,7 @@ def message_handler(_, message):
 
 my_client = SpotWebsocketStreamClient(on_message=message_handler)
 
+my_client.start()
 
 my_client.diff_book_depth(symbol="bnbusdt", speed=1000)
 

--- a/examples/websocket/spot/websocket_stream/partial_book_depth.py
+++ b/examples/websocket/spot/websocket_stream/partial_book_depth.py
@@ -14,6 +14,7 @@ def message_handler(_, message):
 
 my_client = SpotWebsocketStreamClient(on_message=message_handler)
 
+my_client.start()
 
 my_client.partial_book_depth(symbol="bnbusdt", level=10, speed=1000)
 

--- a/examples/websocket/spot/websocket_stream/rolling_window_ticker.py
+++ b/examples/websocket/spot/websocket_stream/rolling_window_ticker.py
@@ -14,6 +14,7 @@ def message_handler(_, message):
 
 my_client = SpotWebsocketStreamClient(on_message=message_handler)
 
+my_client.start()
 
 my_client.rolling_window_ticker("BNBUSDT", "1h")
 

--- a/examples/websocket/spot/websocket_stream/rolling_window_ticker_all_symbols.py
+++ b/examples/websocket/spot/websocket_stream/rolling_window_ticker_all_symbols.py
@@ -14,6 +14,7 @@ def message_handler(_, message):
 
 my_client = SpotWebsocketStreamClient(on_message=message_handler)
 
+my_client.start()
 
 my_client.rolling_window_ticker_all_symbols(windowSize="1h")
 

--- a/examples/websocket/spot/websocket_stream/symbol_kline.py
+++ b/examples/websocket/spot/websocket_stream/symbol_kline.py
@@ -14,6 +14,7 @@ def message_handler(_, message):
 
 my_client = SpotWebsocketStreamClient(on_message=message_handler, is_combined=True)
 
+my_client.start()
 
 # subscribe btcusdt 1m kline
 my_client.kline(symbol="btcusdt", interval="1m")

--- a/examples/websocket/spot/websocket_stream/symbol_mini_ticker.py
+++ b/examples/websocket/spot/websocket_stream/symbol_mini_ticker.py
@@ -14,6 +14,7 @@ def message_handler(_, message):
 
 my_client = SpotWebsocketStreamClient(on_message=message_handler)
 
+my_client.start()
 
 my_client.mini_ticker(symbol="bnbusdt")
 

--- a/examples/websocket/spot/websocket_stream/symbol_ticker.py
+++ b/examples/websocket/spot/websocket_stream/symbol_ticker.py
@@ -14,6 +14,7 @@ def message_handler(_, message):
 
 my_client = Client(on_message=message_handler)
 
+my_client.start()
 
 my_client.ticker(symbol="bnbusdt")
 

--- a/examples/websocket/spot/websocket_stream/test.py
+++ b/examples/websocket/spot/websocket_stream/test.py
@@ -37,6 +37,8 @@ my_client = Client(
     is_combined=True,
 )
 
+my_client.start()
+
 
 my_client.kline(symbol="bnbusdt", interval="1m")
 

--- a/examples/websocket/spot/websocket_stream/trade.py
+++ b/examples/websocket/spot/websocket_stream/trade.py
@@ -14,6 +14,7 @@ def message_handler(_, message):
 
 my_client = SpotWebsocketStreamClient(on_message=message_handler)
 
+my_client.start()
 
 my_client.trade(symbol="bnbusdt")
 

--- a/examples/websocket/spot/websocket_stream/user_data.py
+++ b/examples/websocket/spot/websocket_stream/user_data.py
@@ -27,6 +27,8 @@ ws_client = SpotWebsocketStreamClient(
     stream_url="wss://testnet.binance.vision", on_message=message_handler
 )
 
+ws_client.start()
+
 ws_client.user_data(listen_key=response["listenKey"])
 
 time.sleep(30)


### PR DESCRIPTION
## Problem

The current implementation of the `BinanceWebsocketClient` class lacks a straightforward mechanism for explicit control over when the WebSocket client's thread starts. In many real-world scenarios, users of the library may require fine-grained control over WebSocket connection initialization to coordinate the client's behavior with other parts of their application.

## Solution

This pull request introduces a `start` method to the `BinanceWebsocketClient` class. The purpose of this method is to provide users with explicit control over when the WebSocket client's background thread begins its execution.

## Benefits

- **Explicit Control**: By adding the `start` method, users can initialize the WebSocket client thread at a specific point in their application's workflow. This is invaluable in situations where coordination with other parts of the application is required.

- **Improved Flexibility**: Users can configure event handlers and make any necessary setup adjustments before explicitly starting the client, ensuring a more organized and predictable execution.

- **Enhanced Debugging and Logging**: The `start` method allows for the inclusion of debug log statements, which aid in monitoring and diagnosing any issues during the WebSocket client's execution.

## Impact

This feature is non-intrusive and provides an additional layer of control to users who require it. It doesn't affect the current functionality of the BinanceWebsocketClient class unless the new method is explicitly used.

## Usage Example

```python
# Instantiate the WebSocket client
ws_client = BinanceWebsocketClient(stream_url, on_message=my_message_handler)

# Configure event handlers, etc.

# Explicitly start the WebSocket client when ready
ws_client.start()

# Perform other tasks

# Stop the WebSocket client when no longer needed
ws_client.stop()
