### PR TITLE
websocket_api: exchange_info: Add missing 'params' field to payload

### DIFF
--- a/binance/websocket/spot/websocket_api/_market.py
+++ b/binance/websocket/spot/websocket_api/_market.py
@@ -223,7 +223,7 @@ def exchange_info(self, **kwargs):
             "Only one of symbol, symbols or permissions is required."
         )
 
-    payload = {"id": parameters.pop("id", get_uuid()), "method": "exchangeInfo"}
+    payload = {"id": parameters.pop("id", get_uuid()), "method": "exchangeInfo", "params": parameters}
 
     self.send(payload)
 


### PR DESCRIPTION
* In the 'exchangeInfo' payload construction, the 'params' field was missing, which is required if symbol (or symbols) is given.

* Fixes: https://github.com/binance/binance-connector-python/issues/305