### PR TITLE
Add new methods to Binance API class

### DIFF
--- a/binance/api.py
+++ b/binance/api.py
@@ -195,3 +195,20 @@ class API(object):
                 status_code, err["code"], err["msg"], response.headers, error_data
             )
         raise ServerError(status_code, response.text)
+
+    def get_server_time(self):
+        """Fetch the server time from the Binance API"""
+        url_path = "/api/v3/time"
+        return self.query(url_path)
+
+    def get_exchange_info(self):
+        """Fetch exchange information from the Binance API"""
+        url_path = "/api/v3/exchangeInfo"
+        return self.query(url_path)
+
+    def get_order_book(self, symbol, limit=100):
+        """Fetch the order book for a specific symbol from the Binance API"""
+        check_required_parameter(symbol, "symbol")
+        url_path = "/api/v3/depth"
+        payload = {"symbol": symbol, "limit": limit}
+        return self.query(url_path, payload)

--- a/binance/error.py
+++ b/binance/error.py
@@ -60,3 +60,13 @@ class WebsocketClientError(Error):
 
     def __str__(self):
         return self.error_message
+
+
+class ExchangeError(Error):
+    def __init__(self, message):
+        self.message = message
+
+
+class OrderBookError(Error):
+    def __init__(self, message):
+        self.message = message

--- a/binance/lib/utils.py
+++ b/binance/lib/utils.py
@@ -132,3 +132,21 @@ def parse_proxies(proxies: dict):
             else None
         ),
     }
+
+
+def validate_symbol(symbol):
+    """Validate the format of a trading symbol"""
+    if not isinstance(symbol, str) or not symbol.isalnum():
+        raise ValueError("Invalid symbol format")
+    return True
+
+
+def parse_order_book(order_book_data):
+    """Parse the order book data returned by the Binance API"""
+    if not isinstance(order_book_data, dict):
+        raise ValueError("Invalid order book data format")
+    return {
+        "lastUpdateId": order_book_data.get("lastUpdateId"),
+        "bids": order_book_data.get("bids", []),
+        "asks": order_book_data.get("asks", []),
+    }

--- a/binance/websocket/binance_socket_manager.py
+++ b/binance/websocket/binance_socket_manager.py
@@ -136,3 +136,18 @@ class BinanceSocketManager(threading.Thread):
             self.on_error(self, e)
         else:
             raise e
+
+    def subscribe_to_agg_trades(self, symbol):
+        """Subscribe to aggregate trade streams"""
+        stream_name = f"{symbol.lower()}@aggTrade"
+        self.send_message(json.dumps({"method": "SUBSCRIBE", "params": [stream_name], "id": 1}))
+
+    def subscribe_to_kline(self, symbol, interval):
+        """Subscribe to kline/candlestick streams"""
+        stream_name = f"{symbol.lower()}@kline_{interval}"
+        self.send_message(json.dumps({"method": "SUBSCRIBE", "params": [stream_name], "id": 1}))
+
+    def subscribe_to_order_book(self, symbol, level=5):
+        """Subscribe to order book streams"""
+        stream_name = f"{symbol.lower()}@depth{level}"
+        self.send_message(json.dumps({"method": "SUBSCRIBE", "params": [stream_name], "id": 1}))


### PR DESCRIPTION
Add new methods to `API` class in `binance/api.py` to fetch server time, exchange information, and order book.

* **API Class Enhancements**
  - Add `get_server_time` method to fetch server time from the Binance API.
  - Add `get_exchange_info` method to fetch exchange information from the Binance API.
  - Add `get_order_book` method to fetch the order book for a specific symbol from the Binance API.

* **Error Handling Enhancements**
  - Add `ExchangeError` class to handle errors related to exchange information.
  - Add `OrderBookError` class to handle errors related to fetching the order book.

* **Utility Functions Enhancements**
  - Add `validate_symbol` function to validate the format of a trading symbol.
  - Add `parse_order_book` function to parse the order book data returned by the Binance API.

* **WebSocket Manager Enhancements**
  - Add `subscribe_to_agg_trades` method to subscribe to aggregate trade streams.
  - Add `subscribe_to_kline` method to subscribe to kline/candlestick streams.
  - Add `subscribe_to_order_book` method to subscribe to order book streams.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/binance/binance-connector-python/pull/373?shareId=cad274a6-f60d-4256-acd4-9b33cdb0bf5a).