### PR TITLE
Expose raw `Response`

### DIFF
--- a/common/src/binance_common/models.py
+++ b/common/src/binance_common/models.py
@@ -1,6 +1,8 @@
 from typing import List, Optional, Callable, TypeVar, Generic
 from pydantic import BaseModel
 
+from requests import Response
+
 T = TypeVar("T")
 
 
@@ -35,12 +37,14 @@ class ApiResponse(Generic[T]):
         data_function: Callable[[], T],
         status: int,
         headers: dict,
-        rate_limits: List[RateLimit] = None,
+        rate_limits: List[RateLimit] = [],
+        raw: Optional[Response] = None,
     ):
         self._data_function = data_function
         self.status = status
         self.headers = headers or {}
         self.rate_limits = rate_limits or []
+        self.raw = raw
 
     def data(self) -> T:
         """Lazily retrieves the response data.

--- a/common/src/binance_common/utils.py
+++ b/common/src/binance_common/utils.py
@@ -351,6 +351,7 @@ def send_request(
                 status=response.status_code,
                 headers=response.headers,
                 rate_limits=parse_rate_limit_headers(response.headers),
+                raw=response,
             )
         except requests.RequestException as e:
             attempt += 1


### PR DESCRIPTION
I have seen a couple of mismatched types and some were too subtle and hidden away by the pre-defined schema.
Exposing the raw `Response` allows user to work directly with the raw response content

## Steps to reproduce

For example:
```python
# ... usual setups
response = client.rest_api.get_simple_earn_flexible_product_list()
data: GetSimpleEarnLockedProductListResponse = response.data()

data.rows[0].tier_annual_percentage_rate
# GetFlexibleProductPositionResponseRowsInnerTierAnnualPercentageRate(var_0_5_btc=None, var_5_10_btc=None, additional_properties={})

response.raw.json()["rows"][0]["tierAnnualPercentageRate"]
# {'0-300FDUSD': '0.10000000'}

```

Related issues - https://github.com/binance/binance-connector-python/issues/404