### PR TITLE
Release Common v3.0.0

### DIFF
--- a/common/CHANGELOG.md
+++ b/common/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 3.0.0 - 2025-09-05
+
+### Added (2)
+
+- Support automatic session re-logon on reconncetions/renewals when session is already logged on (`Session re-logon` option on `WebSocketAPIBase`).
+- Added the `api_key` parameter to include `apiKey` in WebsocketAPI request parameters.
+
+### Changed (2)
+
+- Fixed return type mismatch by returning the raw value.
+- Updated `WebsocketAPI` user data return value to match its type.
+
 ## 2.0.0 - 2025-08-22
 
 ### Changed (3)

--- a/common/pyproject.toml
+++ b/common/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "binance-common"
-version = "2.0.0"
+version = "3.0.0"
 description = "Binance Common Types and Utilities for Binance Connectors"
 authors = ["Binance"]
 license = "MIT"

--- a/common/src/binance_common/configuration.py
+++ b/common/src/binance_common/configuration.py
@@ -94,6 +94,7 @@ class ConfigurationWebSocketAPI:
     - WebSocket Pool
     - Time Unit
     - Proxy support
+    - Session re-logon
     """
 
     def __init__(
@@ -111,6 +112,7 @@ class ConfigurationWebSocketAPI:
         pool_size: int = 2,
         time_unit: TimeUnit = None,
         https_agent: Optional[ssl.SSLContext] = None,
+        session_re_logon: Optional[bool] = True,
     ):
         """
         Initialize the API configuration.
@@ -129,6 +131,7 @@ class ConfigurationWebSocketAPI:
             pool_size (int): Number of WebSocket connections in pool (default: 2).
             time_unit (Optional[TimeUnit]): Time unit for time-based responses (default: None).
             https_agent (Optional[ssl.SSLContext]): Custom HTTPS Agent (default: None).
+            session_re_logon (Optional[bool]): Enable session re-logon (default: True).
         """
 
         self.api_key = api_key
@@ -145,6 +148,7 @@ class ConfigurationWebSocketAPI:
         self.time_unit = time_unit
         self.https_agent = https_agent
         self.user_agent = ""
+        self.session_re_logon = session_re_logon
 
 
 class ConfigurationWebSocketStreams:

--- a/common/src/binance_common/models.py
+++ b/common/src/binance_common/models.py
@@ -1,6 +1,8 @@
 from typing import List, Optional, Callable, TypeVar, Generic
 from pydantic import BaseModel
 
+from binance_common.signature import Signers
+
 T = TypeVar("T")
 T_Response = TypeVar("T_Response")
 T_Stream = TypeVar("T_Stream")
@@ -107,3 +109,31 @@ class WebsocketApiUserDataStreamResponse(Generic[T_Response, T_Stream]):
     ):
         self.response = response
         self.stream = stream
+
+
+class WebsocketApiOptions(Generic[T]):
+    """Options for configuring WebSocket API connections.
+
+    :param api_key: A boolean flag indicating whether to include the API key in the request.
+    :param is_signed: A boolean flag indicating whether the request should be signed.
+    :param skip_auth: A boolean flag indicating whether to skip authentication.
+    :param signer: An optional Signers instance for signing requests.
+    """
+
+    def __init__(
+        self,
+        api_key: bool = False,
+        is_signed: bool = True,
+        skip_auth: bool = True,
+        signer: Optional[Signers] = None,
+    ):
+        self.signer = signer
+        self.api_key = api_key
+        self.is_signed = is_signed
+        self.skip_auth = skip_auth
+
+class WebsocketApiUserDataEndpoints(BaseModel):
+    """Represents the WebSocket user data endpoints."""
+
+    user_data_stream_subscribe: str
+    user_data_stream_logout: str

--- a/common/src/binance_common/utils.py
+++ b/common/src/binance_common/utils.py
@@ -608,7 +608,10 @@ def ws_api_payload(config, payload: Dict, websocket_options: WebsocketApiOptions
     }
 
     if websocket_options.is_signed:
-        payload["params"] = websocket_api_signature(config, payload["params"], websocket_options.signer)
+        if websocket_options.skip_auth is True:
+            payload["params"]["timestamp"] = get_timestamp()
+        else:
+            payload["params"] = websocket_api_signature(config, payload["params"], websocket_options.signer)
 
     return payload
 

--- a/common/src/binance_common/utils.py
+++ b/common/src/binance_common/utils.py
@@ -1,5 +1,7 @@
+import copy
 import hashlib
 import hmac
+import importlib
 import json
 import re
 import requests
@@ -9,11 +11,12 @@ import time
 import uuid
 
 from base64 import b64encode
+from collections import OrderedDict
 from Crypto.Hash import SHA256
 from Crypto.Signature.pkcs1_15 import PKCS115_SigScheme
 from enum import Enum
 from pydantic import BaseModel
-from typing import Dict, List, Optional, Type, TypeVar, Union
+from typing import Dict, List, Optional, Type, TypeVar, Union, get_args
 from urllib.parse import urlencode
 from urllib3.util.ssl_ import create_urllib3_context
 
@@ -30,7 +33,12 @@ from binance_common.errors import (
     TooManyRequestsError,
     UnauthorizedError,
 )
-from binance_common.models import ApiResponse, RateLimit, WebsocketApiRateLimit
+from binance_common.models import (
+    ApiResponse,
+    RateLimit,
+    WebsocketApiOptions,
+    WebsocketApiRateLimit
+)
 from binance_common.signature import Signers
 
 
@@ -346,8 +354,14 @@ def send_request(
             else:
                 data_function = lambda: response_model.model_validate(parsed)
 
+            try:
+                data_function()  
+                final_data_function = data_function
+            except Exception:
+                final_data_function = lambda: parsed
+
             return ApiResponse[T](
-                data_function=data_function,
+                data_function=final_data_function,
                 status=response.status_code,
                 headers=response.headers,
                 rate_limits=parse_rate_limit_headers(response.headers),
@@ -506,6 +520,7 @@ def ws_streams_placeholder(stream: str, params: dict = {}) -> str:
         stream,
     )
 
+
 def parse_ws_rate_limit_headers(
     headers: List[Dict[str, Union[str, int]]],
 ) -> List[WebsocketApiRateLimit]:
@@ -521,6 +536,7 @@ def parse_ws_rate_limit_headers(
     for header in headers:
         rate_limits.append(WebsocketApiRateLimit(**header))
     return rate_limits
+
 
 def normalize_query_values(parsed, expected_types=None):
     """Normalizes the values in a parsed query dictionary.
@@ -563,3 +579,141 @@ def normalize_query_values(parsed, expected_types=None):
         normalized[k] = converted[0] if len(converted) == 1 else converted
 
     return normalized
+
+
+def ws_api_payload(config, payload: Dict, websocket_options: WebsocketApiOptions):
+    """Generate payload for websocket API
+
+    Args:
+        config: The API configuration.
+        payload (Dict): The payload to send.
+        websocket_options (WebsocketApiOptions): The WebSocket API options.
+
+    Returns:
+        Dict: The generated payload for the WebSocket API.
+    """
+
+    payload = copy.copy(payload)
+
+    if websocket_options.api_key and websocket_options.skip_auth is False:
+        payload["params"]["apiKey"] = config.api_key
+
+    payload["id"] = payload["id"] if "id" in payload else get_uuid()
+
+    payload["params"] = {
+        snake_to_camel(k): json.dumps(make_serializable(v), separators=(",", ":"))
+        if isinstance(v, (list, dict))
+        else make_serializable(v)
+        for k, v in payload["params"].items()
+    }
+
+    if websocket_options.is_signed:
+        payload["params"] = websocket_api_signature(config, payload["params"], websocket_options.signer)
+
+    return payload
+
+
+def websocket_api_signature(config, payload: Optional[Dict] = {}, signer: Signers = None) -> dict:
+    """Generate signature for websocket API
+
+    Args:
+        payload (Optional[Dict]): Payload.
+        signer (Signers): Signer for the payload.
+    Returns:
+        dict: The generated signature for the WebSocket API.
+    """
+
+    payload["apiKey"] = config.api_key
+    payload["timestamp"] = get_timestamp()
+    parameters = OrderedDict(sorted(payload.items()))
+    parameters["signature"] = get_signature(
+        config, urlencode(parameters), signer
+    )
+    return parameters
+
+
+def get_validator_field_map(response_model_cls: Type[BaseModel]) -> dict[str, str]:
+    """Map User Data response schema class name to oneof_schema_N_validator field dynamically
+
+    Args:
+        response_model_cls (Type[BaseModel]): The response model class.
+
+    Returns:
+        dict[str, str]: The mapping of field names to validator field names.
+    """
+
+    field_map = {}
+    annotations = getattr(response_model_cls, "__annotations__", {})
+
+    for field_name, annotation in annotations.items():
+        if field_name.startswith("oneof_schema_") and field_name.endswith("_validator"):
+            if getattr(annotation, "__origin__", None) is Union:
+                type_ = next((arg for arg in get_args(annotation) if arg is not type(None)), None)
+            else:
+                type_ = annotation
+            if isinstance(type_, str):
+                type_ = re.sub(r'^Optional\[(.*)\]$', r'\1', type_)
+
+            if type_:
+                field_map[type_] = field_name
+
+    return field_map
+
+
+def resolve_model_from_event(response_model_cls: Type[BaseModel], event_name: str) -> Type[BaseModel]:
+    """Resolve the correct model class for the websocket event dynamically.
+
+    Args:
+        response_model_cls (Type[BaseModel]): The response model class.
+        event_name (str): The name of the event.
+
+    Returns:
+        Type[BaseModel]: The resolved model class or None.
+    """
+
+    if not event_name:
+        return None
+
+    one_of_schemas_field = response_model_cls.__pydantic_fields__.get("one_of_schemas")
+    if not one_of_schemas_field:
+        return None
+
+    one_of_schemas = list(one_of_schemas_field.default)
+    event_to_class_map = {name[0].lower() + name[1:]: name for name in one_of_schemas}
+
+    class_name = event_to_class_map.get(event_name)
+    if not class_name:
+        return None
+
+    module = importlib.import_module(response_model_cls.__module__)
+    return getattr(module, class_name, None)
+
+
+def parse_user_event(payload: dict, response_model_cls: Type[BaseModel]) -> BaseModel:
+    """Parse user event to response model.
+
+    Args:
+        payload (dict): The payload dictionary containing event data.
+        response_model_cls (Type[BaseModel]): The response model class.
+
+    Returns:
+        BaseModel: The parsed response model instance.
+    """
+
+    event_name = payload.get("e")
+    model_cls = resolve_model_from_event(response_model_cls, event_name)
+
+    if not model_cls:
+        return response_model_cls(actual_instance=payload)
+
+    try:
+        instance = model_cls.model_validate(payload)
+        validator_field_map = get_validator_field_map(response_model_cls)
+        kwargs = {"actual_instance": instance}
+        if validator_field := validator_field_map.get(model_cls.__name__):
+            kwargs[validator_field] = instance
+        return response_model_cls(**kwargs)
+
+    except Exception as e:
+        print(f"Failed to parse {event_name}: {e}")
+        return response_model_cls(actual_instance=payload)

--- a/common/tests/unit/test_websocket.py
+++ b/common/tests/unit/test_websocket.py
@@ -7,12 +7,12 @@ import pytest
 
 from unittest.mock import AsyncMock, MagicMock, patch
 from types import SimpleNamespace
-from collections import OrderedDict
 
 from binance_common.configuration import ConfigurationWebSocketAPI
 from binance_common.constants import WebsocketMode
 from binance_common.websocket import (
     global_stream_connections,
+    global_user_stream_connections,
     RequestStream,
     RequestStreamHandle,
     WebSocketStreamBase,
@@ -66,6 +66,7 @@ def mock_connection():
     conn.reconnect = False
     conn.websocket = AsyncMock()
     conn.stream_callback_map = {}
+    conn.response_types = {}
     return conn
 
 
@@ -73,6 +74,13 @@ def mock_connection():
 def mock_registry(monkeypatch):
     mock = type(global_stream_connections)()
     monkeypatch.setattr("binance_common.websocket.global_stream_connections", mock)
+    return mock
+
+
+@pytest.fixture
+def mock_user_registry(monkeypatch):
+    mock = type(global_user_stream_connections)()
+    monkeypatch.setattr("binance_common.websocket.global_user_stream_connections", mock)
     return mock
 
 
@@ -396,6 +404,96 @@ class TestWebSocketCommon:
 
         ws_mock.exception.assert_called_once()
 
+    @pytest.mark.asyncio
+    async def test_reconnect_resubscribes(
+        self, mock_connection, mock_registry, mock_user_registry
+    ):
+        ws_common = WebSocketCommon(MagicMock())
+
+        # Prepare old connection
+        old_conn = mock_connection
+        old_conn.id = "abc"
+        old_conn.pending_request = {"1": MagicMock()}
+        old_conn.session_logon_request = {"method": "session.logon", "params": {}, "id": "1"}
+        old_conn.stream_callback_map = {"user_stream": ["cb1"], "trade": ["cb2"]}
+        old_conn.response_types = {"user_stream": "rtype1", "trade": "rtype2"}
+
+        # Prepare new connection
+        new_conn = MagicMock()
+        new_conn.id = "abc"
+        ws_common.connections = [new_conn]
+
+        # Patch methods
+        ws_common.close_connection = AsyncMock()
+        ws_common.connect = AsyncMock()
+        ws_common.session_re_log_on = AsyncMock()
+        ws_common._resubscribe_user_streams = AsyncMock()
+        ws_common._resubscribe_global_streams = AsyncMock()
+        ws_common.reconnect_tasks = ["abc"]
+
+        config = MagicMock()
+        config.stream_url = "wss://test.com/ws"
+        config.reconnect_delay = 0
+
+        await ws_common.reconnect(old_conn, config)
+
+        ws_common.close_connection.assert_awaited_once_with(old_conn, False)
+        ws_common.connect.assert_awaited_once_with(config.stream_url, config, old_conn.id)
+        ws_common.session_re_log_on.assert_awaited_once_with(old_conn.session_logon_request, new_conn)
+        ws_common._resubscribe_user_streams.assert_awaited_once_with(old_conn, new_conn)
+        ws_common._resubscribe_global_streams.assert_awaited_once_with(old_conn, new_conn)
+        assert "abc" not in ws_common.reconnect_tasks
+        assert old_conn.reconnect is False
+
+    @pytest.mark.asyncio
+    async def test__resubscribe_user_streams(self, mock_connection, mock_user_registry):
+        ws_common = WebSocketCommon(MagicMock())
+
+        old_conn = mock_connection
+        old_conn.id = "abc"
+        old_conn.stream_callback_map = {"user_stream": ["cb1"]}
+        old_conn.response_types = {"user_stream": "rtype1"}
+
+        new_conn = MagicMock()
+        new_conn.stream_callback_map = {}
+        new_conn.response_types = {}
+
+        # Simulate registry containing old mapping
+        mock_user_registry.stream_connections_map = {"user_stream": old_conn}
+
+        with patch.object(WebSocketCommon, "send_message", new_callable=AsyncMock) as mock_send:
+            await ws_common._resubscribe_user_streams(old_conn, new_conn)
+
+            mock_send.assert_awaited_once()
+            assert new_conn.stream_callback_map["user_stream"] == ["cb1"]
+            assert new_conn.response_types["user_stream"] == "rtype1"
+            assert mock_user_registry.stream_connections_map["user_stream"] == new_conn
+
+    @pytest.mark.asyncio
+    async def test__resubscribe_global_streams(self, mock_connection, mock_registry):
+        ws_common = WebSocketCommon(MagicMock())
+
+        old_conn = mock_connection
+        old_conn.id = "abc"
+        old_conn.stream_callback_map = {"trade": ["cb2"]}
+        old_conn.response_types = {"trade": "rtype2"}
+
+        new_conn = MagicMock()
+        new_conn.id = "abc"
+        new_conn.stream_callback_map = {}
+        new_conn.response_types = {}
+
+        # Simulate registry containing old mapping
+        mock_registry.stream_connections_map = {"trade": old_conn}
+
+        with patch.object(WebSocketCommon, "send_message", new_callable=AsyncMock) as mock_send:
+            await ws_common._resubscribe_global_streams(old_conn, new_conn)
+
+            mock_send.assert_awaited_once()
+            assert new_conn.stream_callback_map["trade"] == ["cb2"]
+            assert new_conn.response_types["trade"] == "rtype2"
+            assert mock_registry.stream_connections_map["trade"] == new_conn
+
 
 class TestWebSocketStreamBase:
 
@@ -537,9 +635,10 @@ class TestWebSocketAPIBase:
             result = await ws_api.send_message(payload)
 
             mock_send.assert_awaited_once()
-            assert "id" in payload
-            assert "method" in payload
-            assert "params" in payload
+            sent_payload = mock_send.await_args.args[0]
+            assert "id" in sent_payload
+            assert "method" in sent_payload
+            assert "params" in sent_payload
 
             assert isinstance(result, WebsocketApiResponse)
             assert callable(result._data_function)
@@ -558,8 +657,8 @@ class TestWebSocketAPIBase:
 
         with patch.object(
             WebSocketCommon, "send_message", new_callable=AsyncMock
-        ) as mock_send, patch.object(
-            ws_api, "websocket_api_signature", return_value="signature"
+        ) as mock_send, patch(
+            "binance_common.utils.websocket_api_signature", return_value="signature"
         ) as mock_signature:
 
             mock_future = asyncio.Future()
@@ -569,11 +668,12 @@ class TestWebSocketAPIBase:
             result = await ws_api.send_signed_message(payload)
 
             mock_send.assert_awaited_once()
-            mock_signature.assert_called_once_with({"symbol": "BTCUSDT"}, None)
-            assert "id" in payload
-            assert "method" in payload
-            assert "params" in payload
-            assert payload["params"] == "signature"
+            mock_signature.assert_called_once_with(ws_api.configuration, {"symbol": "BTCUSDT"}, None)
+            sent_payload = mock_send.await_args.args[0]
+            assert "id" in sent_payload
+            assert "method" in sent_payload
+            assert "params" in sent_payload
+            assert sent_payload["params"] == "signature"
 
             assert isinstance(result, WebsocketApiResponse)
             assert callable(result._data_function)
@@ -626,8 +726,8 @@ class TestWebSocketAPIBase:
 
         with patch.object(
             WebSocketCommon, "send_message", new_callable=AsyncMock
-        ) as mock_send, patch.object(
-            ws_api, "websocket_api_signature", return_value="signature"
+        ) as mock_send, patch(
+            "binance_common.utils.websocket_api_signature", return_value="signature"
         ) as mock_signature:
 
             hanging_future = asyncio.Future()
@@ -636,11 +736,12 @@ class TestWebSocketAPIBase:
             result = await ws_api.send_signed_message(payload)
 
             mock_send.assert_awaited_once()
-            mock_signature.assert_called_once_with({"symbol": "BTCUSDT"}, None)
-            assert "id" in payload
-            assert "method" in payload
-            assert "params" in payload
-            assert payload["params"] == "signature"
+            mock_signature.assert_called_once_with(ws_api.configuration, {"symbol": "BTCUSDT"}, None)
+            sent_payload = mock_send.await_args.args[0]
+            assert "id" in sent_payload
+            assert "method" in sent_payload
+            assert "params" in sent_payload
+            assert sent_payload["params"] == "signature"
 
             assert isinstance(result, WebsocketApiResponse)
             assert callable(result._data_function)
@@ -660,11 +761,9 @@ class TestWebSocketAPIBase:
             def __await__(self):
                 raise RuntimeError("Something went wrong")
 
-        with caplog.at_level(logging.WARNING), patch.object(
-            WebSocketCommon,
-            "send_message",
-            new=AsyncMock(return_value=ExplodingFuture()),
-        ), patch.object(ws_api, "websocket_api_signature", return_value="signature"):
+        with caplog.at_level(logging.WARNING), \
+            patch.object(WebSocketCommon, "send_message", new=AsyncMock(return_value=ExplodingFuture())), \
+            patch("binance_common.utils.websocket_api_signature", return_value="signature"):
 
             result = await ws_api.send_signed_message(payload)
 
@@ -720,21 +819,6 @@ class TestWebSocketAPIBase:
         assert isinstance(result, WebsocketApiResponse)
         assert result.data() == "Websocket Reconnect"
 
-    def test_websocket_api_signature(self, ws_api):
-        with patch(
-            "binance_common.websocket.get_timestamp", return_value=1234567890
-        ), patch(
-            "binance_common.websocket.get_signature", return_value="mocked-signature"
-        ):
-
-            result = ws_api.websocket_api_signature({"foo": "bar"})
-
-            assert isinstance(result, OrderedDict)
-            assert result["apiKey"] == "test-api-key"
-            assert result["timestamp"] == 1234567890
-            assert result["foo"] == "bar"
-            assert result["signature"] == "mocked-signature"
-
     @pytest.mark.asyncio
     async def test_ping_ws_api(self, ws_api, mock_connection):
         with patch.object(WebSocketCommon, "ping", new_callable=AsyncMock) as mock_ping:
@@ -753,25 +837,28 @@ class TestWebSocketAPIBase:
 
     @pytest.mark.asyncio
     async def test_subscribe_adds_stream_and_callback(
-        self, ws_api, mock_connection, mock_registry
+        self, ws_api, mock_connection, mock_user_registry
     ):
         ws_api.connections = [mock_connection]
-        await ws_api.subscribe_user_data(id="0")
+        await ws_api.subscribe_user_data(id="0", response_model=dict)
 
-        assert "0" in mock_registry.stream_connections_map
-        assert mock_registry.stream_connections_map["0"] == mock_connection
+        assert "0" in mock_user_registry.stream_connections_map
+        assert mock_user_registry.stream_connections_map["0"] == mock_connection
         assert "0" in mock_connection.stream_callback_map
+        assert "0" in mock_connection.response_types
+        assert mock_connection.response_types["0"] == dict
         await ws_api.unsubscribe(id="0")
 
     @pytest.mark.asyncio
     async def test_on_sets_callback_for_stream(self, ws_api, mock_connection):
         ws_api.connections = [mock_connection]
-        await ws_api.subscribe_user_data(id="0")
+        await ws_api.subscribe_user_data(id="0", response_model=dict)
 
         callback = lambda x: x
         ws_api.on("message", callback, "0")
 
         assert mock_connection.stream_callback_map["0"] == [callback]
+        assert mock_connection.response_types["0"] == dict
 
         callback = lambda x: x
         ws_api.on("message", callback, "0")
@@ -782,12 +869,13 @@ class TestWebSocketAPIBase:
     @pytest.mark.asyncio
     async def test_on_sets_callback_for_stream(self, ws_api, mock_connection):
         ws_api.connections = [mock_connection]
-        await ws_api.subscribe_user_data(id="0")
+        await ws_api.subscribe_user_data(id="0", response_model=dict)
 
         callback = lambda x: x
         ws_api.on("message", callback, "0")
 
         assert mock_connection.stream_callback_map["0"] == [callback]
+        assert mock_connection.response_types["0"] == dict
         await ws_api.unsubscribe(id="0")
 
     @pytest.mark.asyncio
@@ -797,13 +885,13 @@ class TestWebSocketAPIBase:
 
     @pytest.mark.asyncio
     async def test_unsubscribe_removes_stream(
-        self, ws_api, mock_connection, mock_registry
+        self, ws_api, mock_connection, mock_user_registry
     ):
         ws_api.connections = [mock_connection]
         await ws_api.subscribe_user_data(id="0")
         await ws_api.unsubscribe(id="0")
 
-        assert "test_stream" not in mock_registry.stream_connections_map
+        assert "test_stream" not in mock_user_registry.stream_connections_map
 
     @pytest.mark.asyncio
     async def test_unsubscribe_with_empty_streams(self, ws_api, caplog):


### PR DESCRIPTION
### Added (2)

- Support automatic session re-logon on reconnections/renewals when session is already logged on (`Session re-logon` option on `WebSocketAPIBase`).
- Added the `api_key` parameter to include `apiKey` in WebsocketAPI request parameters.

### Changed (2)

- Fixed return type mismatch by returning the raw value.
- Updated `WebsocketAPI` user data return value to match its type.