### PR TITLE
Update pyproject.toml

### DIFF
--- a/clients/spot/pyproject.toml
+++ b/clients/spot/pyproject.toml
@@ -16,20 +16,20 @@ requests = ">=2.31.0"
 pydantic = ">=2.10.0"
 websockets = "^15.0.1"
 websocket-client = ">=1.6.3"
-black = "^25.1.0"
-ruff = "^0.12.0"
+
 pycryptodome = "^3.17"
 aiohttp = "^3.9"
 binance-common = "3.2.0"
-pytest = { version = ">=6.2.5", optional = true }
 
 [tool.poetry.extras]
 dev = ["pytest"]
 
 [tool.poetry.group.dev.dependencies]
 tox = "^4.27.0"
-pytest = ">=8.4.1"
 pytest-asyncio = "^1.0.0"
+black = "^25.1.0"
+ruff = "^0.12.0"
+pytest = ">=8.4.1"
 
 [tool.ruff]
 exclude = [".git", ".tox", "build", "dist"]


### PR DESCRIPTION
Currently black and ruff are mandatory dependencies that makes the project imposible to install if you are using more moderen versions of ruff