### PR TITLE
Release Common v3.3.0

### DIFF
--- a/common/CHANGELOG.md
+++ b/common/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 3.3.0 - 2025-12-22
+
+### Changed (6)
+
+- Added `body` parameter to `send_request` function for Rest API http requests.
+- Added `return_rate_limits` parameter to `ConfigurationWebSocketAPI` to avoid receiving rate limit headers.
+- Added `id_strict_int` parameter to `WebSocketStreamBase` to fix `Derivatives Trading Options` error.
+- Updated returned error value in `send_request` function.
+- Updated Websocket `timeout` and `reconnect_delay` to be in milliseconds.
+- Updated `backoff` to be in milliseconds.
+
 ## 3.2.0 - 2025-10-10
 
 ### Changed (1)

--- a/common/pyproject.toml
+++ b/common/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "binance-common"
-version = "3.2.0"
+version = "3.3.0"
 description = "Binance Common Types and Utilities for Binance Connectors"
 authors = ["Binance"]
 license = "MIT"
@@ -11,7 +11,7 @@ packages = [
 ]
 
 [tool.poetry.dependencies]
-python = ">=3.9,<3.14"
+python = ">=3.9,<3.15"
 requests = ">=2.31.0"
 pydantic = ">=2.10.0"
 websockets = "^15.0.1"

--- a/common/src/binance_common/configuration.py
+++ b/common/src/binance_common/configuration.py
@@ -104,8 +104,8 @@ class ConfigurationWebSocketAPI:
         private_key: Optional[Union[bytes, str]] = None,
         private_key_passphrase: Optional[str] = None,
         stream_url: str = "wss://ws-api.binance.com/ws-api/v3",
-        timeout: int = 5,
-        reconnect_delay: int = 5,
+        timeout: int = 5000,
+        reconnect_delay: int = 5000,
         compression: int = 0,
         proxy: Optional[Dict[str, Union[str, int, Dict[str, str]]]] = None,
         mode: WebsocketMode = WebsocketMode.SINGLE,
@@ -113,6 +113,7 @@ class ConfigurationWebSocketAPI:
         time_unit: TimeUnit = None,
         https_agent: Optional[ssl.SSLContext] = None,
         session_re_logon: Optional[bool] = True,
+        return_rate_limits: Optional[bool] = True
     ):
         """
         Initialize the API configuration.
@@ -132,6 +133,7 @@ class ConfigurationWebSocketAPI:
             time_unit (Optional[TimeUnit]): Time unit for time-based responses (default: None).
             https_agent (Optional[ssl.SSLContext]): Custom HTTPS Agent (default: None).
             session_re_logon (Optional[bool]): Enable session re-logon (default: True).
+            return_rate_limits (Optional[bool]): Enable rate limits returns (default: True).
         """
 
         self.api_key = api_key
@@ -149,6 +151,7 @@ class ConfigurationWebSocketAPI:
         self.https_agent = https_agent
         self.user_agent = ""
         self.session_re_logon = session_re_logon
+        self.return_rate_limits = return_rate_limits
 
 
 class ConfigurationWebSocketStreams:
@@ -166,7 +169,7 @@ class ConfigurationWebSocketStreams:
     def __init__(
         self,
         stream_url: str = "wss://stream.binance.com:9443/stream",
-        reconnect_delay: int = 5,
+        reconnect_delay: int = 5000,
         compression: int = 0,
         proxy: Optional[Dict[str, Union[str, int, Dict[str, str]]]] = None,
         mode: WebsocketMode = WebsocketMode.SINGLE,

--- a/common/src/binance_common/errors.py
+++ b/common/src/binance_common/errors.py
@@ -8,9 +8,10 @@ class Error(Exception):
 class ClientError(Error):
     """Represents an error that occurred in the Connector client."""
 
-    def __init__(self, error_message: Optional[str] = None):
+    def __init__(self, error_message: Optional[str] = None, status_code: Optional[int] = None):
         self.error_message = error_message or "An unexpected error occurred."
-        super().__init__(error_message)
+        self.status_code = status_code
+        super().__init__(self.status_code, self.error_message)
 
 
 class RequiredError(Error):
@@ -27,43 +28,43 @@ class RequiredError(Error):
 class UnauthorizedError(Error):
     """Represents an error when a client is unauthorized to access a resource."""
 
-    def __init__(self, error_message: Optional[str] = None):
+    def __init__(self, error_message: Optional[str] = None, status_code: Optional[int] = None):
         self.error_message = (
             error_message or "Unauthorized access. Authentication required."
         )
-        super().__init__(error_message)
-
+        self.status_code = status_code
+        super().__init__(self.status_code, self.error_message)
 
 class ForbiddenError(Error):
     """Represents an error when access to the resource is forbidden."""
 
-    def __init__(self, error_message: Optional[str] = None):
+    def __init__(self, error_message: Optional[str] = None, status_code: Optional[int] = None):
         self.error_message = (
             error_message or "Access to the requested resource is forbidden."
         )
-        super().__init__(error_message)
-
+        self.status_code = status_code
+        super().__init__(self.status_code, self.error_message)
 
 class TooManyRequestsError(Error):
     """Represents an error when the client is doing too many requests."""
 
-    def __init__(self, error_message: Optional[str] = None):
+    def __init__(self, error_message: Optional[str] = None, status_code: Optional[int] = None):
         self.error_message = (
             error_message or "Too many requests. You are being rate-limited."
         )
-        super().__init__(error_message)
-
+        self.status_code = status_code
+        super().__init__(self.status_code, self.error_message)
 
 class RateLimitBanError(Error):
     """Represents an error when the client's IP has been banned for exceeding rate
     limits."""
 
-    def __init__(self, error_message: Optional[str] = None):
+    def __init__(self, error_message: Optional[str] = None, status_code: Optional[int] = None):
         self.error_message = (
             error_message or "The IP address has been banned for exceeding rate limits."
         )
-        super().__init__(error_message)
-
+        self.status_code = status_code
+        super().__init__(self.status_code, self.error_message)
 
 class ServerError(Error):
     """Represents an error when there is an internal server error."""
@@ -89,16 +90,18 @@ class NetworkError(Error):
 class NotFoundError(Error):
     """Represents an error when the requested resource was not found."""
 
-    def __init__(self, error_message: Optional[str] = None):
+    def __init__(self, error_message: Optional[str] = None, status_code: Optional[int] = None):
         self.error_message = error_message or "The requested resource was not found."
-        super().__init__(error_message)
+        self.status_code = status_code
+        super().__init__(self.status_code, self.error_message)
 
 
 class BadRequestError(Error):
     """Represents an error when a request is invalid or cannot be otherwise served."""
 
-    def __init__(self, error_message: Optional[str] = None):
+    def __init__(self, error_message: Optional[str] = None, status_code: Optional[int] = None):
         self.error_message = (
             error_message or "The request was invalid or cannot be otherwise served."
         )
-        super().__init__(self.error_message)
+        self.status_code = status_code
+        super().__init__(self.status_code, self.error_message)


### PR DESCRIPTION
### Changed (6)

- Added `body` parameter to `send_request` function for Rest API http requests.
- Added `return_rate_limits` parameter to `ConfigurationWebSocketAPI` to avoid receiving rate limit headers.
- Added `id_strict_int` parameter to `WebSocketStreamBase` to fix `Derivatives Trading Options` error.
- Updated returned error value in `send_request` function.
- Updated Websocket `timeout` and `reconnect_delay` to be in milliseconds.
- Updated `backoff` to be in milliseconds.