### PR TITLE
Release Common v3.6.0

### DIFF
--- a/common/CHANGELOG.md
+++ b/common/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 3.6.0 - 2026-02-11
+
+### Updated (2)
+
+- Updated `ws_api_payload` function to include the `id` sent in the payload.
+- Updated `pyproject.toml` dependencies
+
 ## 3.5.0 - 2026-01-29
 
 ### Updated (1)

--- a/common/pyproject.toml
+++ b/common/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "binance-common"
-version = "3.5.0"
+version = "3.6.0"
 description = "Binance Common Types and Utilities for Binance Connectors"
 authors = ["Binance"]
 license = "MIT"
@@ -15,19 +15,18 @@ python = ">=3.9,<3.15"
 requests = ">=2.31.0"
 pydantic = ">=2.10.0"
 websockets = "^15.0.1"
-black = "^25.1.0"
-ruff = "^0.12.0"
 pycryptodome = "^3.17"
 aiohttp = "^3.9"
-pytest = { version = ">=6.2.5", optional = true }
 
 [tool.poetry.extras]
 dev = ["pytest"]
 
 [tool.poetry.group.dev.dependencies]
 tox = "^4.27.0"
-pytest = ">=8.4.1"
 pytest-asyncio = "^1.0.0"
+black = "^25.1.0"
+ruff = "^0.12.0"
+pytest = ">=8.4.1"
 
 [build-system]
 requires = ["poetry-core"]

--- a/common/src/binance_common/utils.py
+++ b/common/src/binance_common/utils.py
@@ -651,7 +651,7 @@ def ws_api_payload(config, payload: Dict, websocket_options: WebsocketApiOptions
     if websocket_options.api_key and websocket_options.skip_auth is False:
         payload["params"]["apiKey"] = config.api_key
 
-    payload["id"] = payload["id"] if "id" in payload else get_uuid()
+    payload["id"] = payload["params"].pop("id", get_uuid())
 
     payload["params"] = {
         snake_to_camel(k): json.dumps(make_serializable(v), separators=(",", ":"))

--- a/common/tests/unit/test_utils.py
+++ b/common/tests/unit/test_utils.py
@@ -1381,30 +1381,32 @@ class TestWsApiPayload(unittest.TestCase):
     def setUp(self):
         self.dummy_config = SimpleNamespace(api_key="test-api-key", api_secret="test-api-secret")
         self.base_payload = {
-            "id": "123",
             "params": {
                 "some_param": "value",
                 "list_param": [1, 2, 3],
-                "dict_param": {"nested": "data"}
+                "dict_param": {"nested": "data"},
+                "id": "123",
             }
         }
 
     def test_payload_with_api_key_and_signed(self):
         websocket_options = WebsocketApiOptions(api_key=True, skip_auth=False, is_signed=True, signer=None)
-        
+        expected_id = self.base_payload["params"]["id"]
+
         with patch("binance_common.utils.websocket_api_signature", return_value={"signed": True}) as mock_signature:
             result = ws_api_payload(self.dummy_config, self.base_payload, websocket_options)
             mock_signature.assert_called_once()
 
-            assert result["id"] == self.base_payload["id"]
+            assert result["id"] == expected_id
             assert result["params"] == {"signed": True}
 
     def test_payload_without_api_key(self):
         websocket_options = WebsocketApiOptions(api_key=False, skip_auth=False, is_signed=False, signer=None)
+        expected_id = self.base_payload["params"]["id"]
         result = ws_api_payload(self.dummy_config, self.base_payload, websocket_options)
 
         assert "apiKey" not in result["params"]
-        assert result["id"] == self.base_payload["id"]
+        assert result["id"] == expected_id
         assert isinstance(result["params"]["listParam"], str)
         assert isinstance(result["params"]["dictParam"], str)
         assert result["params"]["someParam"] == "value"


### PR DESCRIPTION
### Updated (2)

- Updated `ws_api_payload` function to include the `id` sent in the payload.
- Updated `pyproject.toml` dependencies