### PR TITLE
Release Common v3.9.0

### DIFF
--- a/common/CHANGELOG.md
+++ b/common/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 3.9.0 - 2026-04-29
+
+### Updated (1)
+
+- Fix `WebSocketCommon` reconnection logic to properly handle reconnections and avoid multiple concurrent reconnection attempts.
+
 ## 3.8.0 - 2026-03-26
 
 ### Added (2)

--- a/common/pyproject.toml
+++ b/common/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "binance-common"
-version = "3.8.0"
+version = "3.9.0"
 description = "Binance Common Types and Utilities for Binance Connectors"
 authors = ["Binance"]
 license = "MIT"

--- a/common/src/binance_common/websocket.py
+++ b/common/src/binance_common/websocket.py
@@ -410,7 +410,7 @@ class WebSocketCommon:
         if configuration.reconnect_delay:
             await asyncio.sleep(configuration.reconnect_delay / 1000)
 
-        await self.connect(configuration.stream_url, configuration, connection.id)
+        await self.init_connection(configuration.stream_url, configuration, connection.url_path, connection.id)
 
         new_connection = next(
             (c for c in self.connections if c.id == connection.id), None

--- a/common/tests/unit/test_websocket.py
+++ b/common/tests/unit/test_websocket.py
@@ -463,6 +463,7 @@ class TestWebSocketCommon:
         # Prepare old connection
         old_conn = mock_connection
         old_conn.id = "abc"
+        old_conn.url_path = None
         old_conn.pending_request = {"1": MagicMock()}
         old_conn.session_logon_request = {
             "method": "session.logon",
@@ -479,7 +480,7 @@ class TestWebSocketCommon:
 
         # Patch methods
         ws_common.close_connection = AsyncMock()
-        ws_common.connect = AsyncMock()
+        ws_common.init_connection = AsyncMock()
         ws_common.session_re_log_on = AsyncMock()
         ws_common._resubscribe_user_streams = AsyncMock()
         ws_common._resubscribe_global_streams = AsyncMock()
@@ -492,8 +493,8 @@ class TestWebSocketCommon:
         await ws_common.reconnect(old_conn, config)
 
         ws_common.close_connection.assert_awaited_once_with(old_conn, False)
-        ws_common.connect.assert_awaited_once_with(
-            config.stream_url, config, old_conn.id
+        ws_common.init_connection.assert_awaited_once_with(
+            config.stream_url, config, old_conn.url_path, old_conn.id
         )
         ws_common.session_re_log_on.assert_awaited_once_with(
             old_conn.session_logon_request, new_conn


### PR DESCRIPTION
### Updated (1)

- Fix `WebSocketCommon` reconnection logic to properly handle reconnections and avoid multiple concurrent reconnection attempts.